### PR TITLE
Add scenario storage module

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,6 @@
         </div>
     </div>
 
-    <script src="script.js"></script>
+    <script type="module" src="js/marketSimulator.js"></script>
 </body>
-</html> 
+</html>

--- a/index.html
+++ b/index.html
@@ -113,6 +113,6 @@
         </div>
     </div>
 
-    <script type="module" src="js/marketSimulator.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
         </div>
     </div>
 
-    <script type="module" src="script.js"></script>
+    <script src="js/scenarioStore.js"></script>
+    <script src="script.js"></script>
 </body>
 </html>

--- a/js/marketSimulator.js
+++ b/js/marketSimulator.js
@@ -1,3 +1,5 @@
+import { saveScenario } from './scenarioStore.js';
+
 class MarketSimulator {
     constructor() {
         this.chart = null;
@@ -109,7 +111,21 @@ class MarketSimulator {
         this.updateStatistics(results, initialSpot, forecastedRate);
         this.updateContractStatistics(results, volumeDiscount);
         this.updateSuggestedRates(initialSpot, forecastedRate, volatility, weeklyDrift, nSimulations, volumeDiscount);
-        
+
+        // Persist scenario parameters and results
+        saveScenario({
+            parameters: {
+                initialSpot,
+                forecastedRate,
+                volatility,
+                weeks,
+                nSimulations,
+                volumeDiscount
+            },
+            results,
+            timestamp: Date.now()
+        });
+
         console.log('Simulation completed successfully');
     }
 
@@ -579,6 +595,8 @@ class MarketSimulator {
 }
 
 // Initialize the application when the page loads
-document.addEventListener('DOMContentLoaded', function() {
+export default MarketSimulator;
+
+document.addEventListener('DOMContentLoaded', () => {
     new MarketSimulator();
-}); 
+});

--- a/js/scenarioStore.js
+++ b/js/scenarioStore.js
@@ -1,0 +1,18 @@
+export function saveScenario(scenario) {
+    try {
+        const scenarios = JSON.parse(localStorage.getItem('scenarios') || '[]');
+        scenarios.push(scenario);
+        localStorage.setItem('scenarios', JSON.stringify(scenarios));
+    } catch (err) {
+        console.error('Failed to save scenario', err);
+    }
+}
+
+export function getScenarios() {
+    try {
+        return JSON.parse(localStorage.getItem('scenarios') || '[]');
+    } catch (err) {
+        console.error('Failed to load scenarios', err);
+        return [];
+    }
+}

--- a/js/scenarioStore.js
+++ b/js/scenarioStore.js
@@ -1,18 +1,23 @@
-export function saveScenario(scenario) {
-    try {
-        const scenarios = JSON.parse(localStorage.getItem('scenarios') || '[]');
-        scenarios.push(scenario);
-        localStorage.setItem('scenarios', JSON.stringify(scenarios));
-    } catch (err) {
-        console.error('Failed to save scenario', err);
+(function() {
+    function saveScenario(scenario) {
+        try {
+            const scenarios = JSON.parse(localStorage.getItem('scenarios') || '[]');
+            scenarios.push(scenario);
+            localStorage.setItem('scenarios', JSON.stringify(scenarios));
+        } catch (err) {
+            console.error('Failed to save scenario', err);
+        }
     }
-}
 
-export function getScenarios() {
-    try {
-        return JSON.parse(localStorage.getItem('scenarios') || '[]');
-    } catch (err) {
-        console.error('Failed to load scenarios', err);
-        return [];
+    function getScenarios() {
+        try {
+            return JSON.parse(localStorage.getItem('scenarios') || '[]');
+        } catch (err) {
+            console.error('Failed to load scenarios', err);
+            return [];
+        }
     }
-}
+
+    window.saveScenario = saveScenario;
+    window.getScenarios = getScenarios;
+})();

--- a/script.js
+++ b/script.js
@@ -1,5 +1,3 @@
-import { saveScenario } from './js/scenarioStore.js';
-
 class MarketSimulator {
     constructor() {
         this.chart = null;
@@ -112,19 +110,20 @@ class MarketSimulator {
         this.updateContractStatistics(results, volumeDiscount);
         this.updateSuggestedRates(initialSpot, forecastedRate, volatility, weeklyDrift, nSimulations, volumeDiscount);
 
-        // Persist scenario parameters and results
-        saveScenario({
-            parameters: {
-                initialSpot,
-                forecastedRate,
-                volatility,
-                weeks,
-                nSimulations,
-                volumeDiscount
-            },
-            results,
-            timestamp: Date.now()
-        });
+        if (typeof saveScenario === 'function') {
+            saveScenario({
+                parameters: {
+                    initialSpot,
+                    forecastedRate,
+                    volatility,
+                    weeks,
+                    nSimulations,
+                    volumeDiscount
+                },
+                results,
+                timestamp: Date.now()
+            });
+        }
 
         console.log('Simulation completed successfully');
     }
@@ -595,8 +594,6 @@ class MarketSimulator {
 }
 
 // Initialize the application when the page loads
-export default MarketSimulator;
-
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', function() {
     new MarketSimulator();
-});
+}); 

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-import { saveScenario } from './scenarioStore.js';
+import { saveScenario } from './js/scenarioStore.js';
 
 class MarketSimulator {
     constructor() {


### PR DESCRIPTION
## Summary
- split MarketSimulator into `js/marketSimulator.js` module
- add `js/scenarioStore.js` for persisting scenarios in localStorage
- save parameters and results after each simulation run
- load MarketSimulator as a module in `index.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68431edc300c832fac141beb0110bec3